### PR TITLE
Add 'list_servers' tool to retrieve available Discord servers with details such as server ID, name, member count, and creation date

### DIFF
--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -1,15 +1,16 @@
-import os
 import asyncio
 import logging
+import os
 from datetime import datetime
-from typing import Any, Dict, List, Optional
 from functools import wraps
+from typing import Any, Dict, List, Optional
 
 import discord
 from discord.ext import commands
 from mcp.server import Server
-from mcp.types import Tool, TextContent, EmptyResult
 from mcp.server.stdio import stdio_server
+from mcp.types import EmptyResult, TextContent, Tool
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("discord-mcp-server")
@@ -51,6 +52,15 @@ async def list_tools() -> List[Tool]:
     """List available Discord tools."""
     return [
         # Server Information Tools
+        Tool(
+            name="list_servers",
+            description="Get a list of all Discord servers the bot has access to with their details such as name, id, member count, and creation date.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        ),
         Tool(
             name="get_server_info",
             description="Get information about a Discord server",
@@ -458,6 +468,21 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
             text=f"Server Members ({len(members)}):\n" + 
                  "\n".join(f"{m['name']} (ID: {m['id']}, Roles: {', '.join(m['roles'])})" for m in members)
         )]
+    elif name == "list_servers":
+        servers = []
+        for guild in discord_client.guilds:
+            servers.append({
+                "id": str(guild.id),
+                "name": guild.name,
+                "member_count": guild.member_count,
+                "created_at": guild.created_at.isoformat()
+            })
+        
+        return [TextContent(
+            type="text",
+            text=f"Available Servers ({len(servers)}):\n" + 
+                "\n".join(f"{s['name']} (ID: {s['id']}, Members: {s['member_count']})" for s in servers)
+        )]
 
     # Role Management Tools
     elif name == "add_role":
@@ -553,4 +578,4 @@ async def main():
         )
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(main())    asyncio.run(main())    asyncio.run(main())

--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -578,4 +578,4 @@ async def main():
         )
 
 if __name__ == "__main__":
-    asyncio.run(main())    asyncio.run(main())    asyncio.run(main())
+    asyncio.run(main())


### PR DESCRIPTION
This PR adds a new tool that allows listing all Discord servers (guilds) the bot has access to without requiring a specific server ID. This makes it easier for users to discover available servers before using other server-specific functions.

Features:
- Added new Tool definition for list_servers in list_tools()
- Implemented list_servers handler in call_tool() function
- Returns server name, ID, member count, and creation date for each available server
- No input parameters required

Validated functionality using MCP Inspector as shown in the attached screenshot.

<img width="1796" alt="Screenshot 2025-04-09 at 20 28 12" src="https://github.com/user-attachments/assets/905d95a0-7f87-4398-b4b4-ea9aadef4576" />
