### PR TITLE
Fix: double f strings bug

### DIFF
--- a/src/discord_mcp/server.py
+++ b/src/discord_mcp/server.py
@@ -366,12 +366,16 @@ async def call_tool(name: str, arguments: Any) -> List[TextContent]:
                 "timestamp": message.created_at.isoformat(),
                 "reactions": reaction_data  # Add reactions to message dict
             })
+        # Helper function to format reactions
+        def format_reaction(r):
+            return f"{r['emoji']}({r['count']})"
+            
         return [TextContent(
             type="text",
             text=f"Retrieved {len(messages)} messages:\n\n" + 
                  "\n".join([
                      f"{m['author']} ({m['timestamp']}): {m['content']}\n" +
-                     f"Reactions: {', '.join([f'{r['emoji']}({r['count']})' for r in m['reactions']]) if m['reactions'] else 'No reactions'}"
+                     f"Reactions: {', '.join([format_reaction(r) for r in m['reactions']]) if m['reactions'] else 'No reactions'}"
                      for m in messages
                  ])
         )]


### PR DESCRIPTION
oh mb for no description thought I committed it to a fork lol

I run into this issue in python 3.12.7:
```
    (', '.join([f'{r['emoji']}({r['count']})' for r in m['reactions']]) if m['reactions'] else 'No reactions')
                      ^^^^^
SyntaxError: f-string: f-string: unmatched '['
```

can we just replace it via helper function? imo with double f strings this is better either way
